### PR TITLE
added pendingPromise boolean to stop api from making calls when a cal…

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -294,3 +294,10 @@ width:50%;
     transform: scale(1.1);
   }
 }
+
+@media screen and (orientation: landscape) {
+  .pins{
+    max-height: 32px;
+    max-width: 32px;
+  }
+}

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -36,7 +36,16 @@ const Map = ({
   // only runs if maps object is populated
   if (!isObjEmpty(mapsObj) && !pendingPromise) {
     const { map } = mapsObj;
-    map.addListener("center_changed", function () {
+    // map.addListener("center_changed", function () {
+    //   const panCoords = map.getCenter();
+    //   const panLat = panCoords.lat();
+    //   const panLng = panCoords.lng();
+    //   setUserHasPanned(true);
+    //   if(!pendingPromise){
+    //     handleCenterChanged(panLat, panLng);
+    //   }
+    // })
+    map.addListener("dragend", function (event) {
       const panCoords = map.getCenter();
       const panLat = panCoords.lat();
       const panLng = panCoords.lng();
@@ -44,10 +53,8 @@ const Map = ({
       if(!pendingPromise){
         handleCenterChanged(panLat, panLng);
       }
-    })
-    map.addListener("drag_end", function (event) {
-        document.getElementById('lat').value = this.position.lat();
-        document.getElementById('lng').value = this.position.lng();
+        // document.getElementById('lat').value = this.position.lat();
+        // document.getElementById('lng').value = this.position.lng();
       });
   };
 

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -22,14 +22,14 @@ const Map = ({
 }) => {
 
   let [pendingPromise, setPendingPromise] = useState(false);
-  
+
   useEffect(() => {
     if (!pendingPromise) {
       fetchNearbyPlaces(
         mapProperties.center.lat,
         mapProperties.center.lng,
         setPendingPromise
-      ).then((res) => setNearbyPlaces(res), setPendingPromise(false));
+      ).then((res) => {setNearbyPlaces(res); setPendingPromise(false);});
     }
   }, [mapProperties.center.lat, mapProperties.center.lng, setNearbyPlaces]);
 
@@ -47,7 +47,7 @@ const Map = ({
 
 
   function handleCenterChanged(panLat, panLng) {
-    fetchNearbyPlaces(panLat, panLng).then((res) => setNearbyPlaces(res));
+    fetchNearbyPlaces(panLat, panLng, setPendingPromise).then((res) => setNearbyPlaces(res));
   }
 
   return (

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -42,18 +42,17 @@ const Map = ({
       const panLat = panCoords.lat();
       const panLng = panCoords.lng();
       setUserHasPanned(true);
-      if(!pendingPromise){
-        handleCenterChanged(panLat, panLng);
-      }
       setTimeout(() => {
-        handleCenterChanged(panLat, panLng);
+        if(!pendingPromise){
+          console.log("ping")
+          handleCenterChanged(panLat, panLng);
+        }
       }, fetchDelay);
      });
   };
 
   function handleCenterChanged(panLat, panLng) {
     if (!pendingPromise) {
-      console.log("handleCenterChange")
       fetchNearbyPlaces(panLat, panLng, setPendingPromise).then((res) => setNearbyPlaces(res));
     }
   }

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import GoogleMapReact from "google-map-react";
 import Pin from "./Pins";
@@ -13,12 +13,16 @@ const Map = ({
   mapProperties,
 }) => {
   useEffect(() => {
-    fetchNearbyPlaces(
-      mapProperties.center.lat,
-      mapProperties.center.lng
-    ).then((res) => setNearbyPlaces(res));
+    if (!pendingPromise) {
+      fetchNearbyPlaces(
+        mapProperties.center.lat,
+        mapProperties.center.lng,
+        setPendingPromise
+      ).then((res) => setNearbyPlaces(res), setPendingPromise(false));
+    }
   }, [mapProperties.center.lat, mapProperties.center.lng, setNearbyPlaces]);
 
+  let [pendingPromise, setPendingPromise] = useState(false);
   return (
     <div style={{ height: "calc(66.67vh - 1.25rem)", width: "100%" }}>
       <GoogleMapReact

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -44,8 +44,13 @@ const Map = ({
       if(!pendingPromise){
         handleCenterChanged(panLat, panLng);
       }
-    });
+    })
+    map.addListener("drag_end", function (event) {
+        document.getElementById('lat').value = this.position.lat();
+        document.getElementById('lng').value = this.position.lng();
+      });
   };
+
 
 
   function handleCenterChanged(panLat, panLng) {

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -44,7 +44,6 @@ const Map = ({
       setUserHasPanned(true);
       setTimeout(() => {
         if(!pendingPromise){
-          console.log("ping")
           handleCenterChanged(panLat, panLng);
         }
       }, fetchDelay);

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -31,23 +31,28 @@ const Map = ({
         setPendingPromise
       ).then((res) => {setNearbyPlaces(res); setPendingPromise(false);});
     }
-  }, [mapProperties.center.lat, mapProperties.center.lng, setNearbyPlaces]);
+  }, []);
 
   // only runs if maps object is populated
-  if (!isObjEmpty(mapsObj)) {
+  if (!isObjEmpty(mapsObj) && !pendingPromise) {
     const { map } = mapsObj;
     map.addListener("center_changed", function () {
       const panCoords = map.getCenter();
       const panLat = panCoords.lat();
       const panLng = panCoords.lng();
       setUserHasPanned(true);
-      handleCenterChanged(panLat, panLng);
+      if(!pendingPromise){
+        handleCenterChanged(panLat, panLng);
+      }
     });
   };
 
 
   function handleCenterChanged(panLat, panLng) {
-    fetchNearbyPlaces(panLat, panLng, setPendingPromise).then((res) => setNearbyPlaces(res));
+    if (!pendingPromise) {
+      console.log("handleCenterChange")
+      fetchNearbyPlaces(panLat, panLng, setPendingPromise).then((res) => setNearbyPlaces(res));
+    }
   }
 
   return (
@@ -57,7 +62,6 @@ const Map = ({
         center={mapProperties.center}
         zoom={mapProperties.zoom}
         options={{ clickableIcons: false, gestureHandling: "greedy" }}
-        handleCenterChanged={handleCenterChanged}
         yesIWantToUseGoogleMapApiInternals
         onGoogleApiLoaded={setMapsObj}
       >

--- a/src/components/Pins.js
+++ b/src/components/Pins.js
@@ -10,9 +10,9 @@ const Pin = ({ image, place, setCurrentPin, setDisplayInformation }) => {
   return (
     <div onClick={onClick} className="pins">
       {image ? (
-        <img src={image} alt={"venues across location"} />
+        <img src={image} alt={"local venue"} />
       ) : (
-        <img src={DEFAULT_IMAGE} alt={"venues across location"} />
+        <img src={DEFAULT_IMAGE} alt={"local venue"} />
       )}
     </div>
   );

--- a/src/components/Pins.js
+++ b/src/components/Pins.js
@@ -10,9 +10,9 @@ const Pin = ({ image, place, setCurrentPin, setDisplayInformation }) => {
   return (
     <div onClick={onClick} className="pins">
       {image ? (
-        <img src={image} alt={"local venue"} />
+        <img src={image} alt={place.title} />
       ) : (
-        <img src={DEFAULT_IMAGE} alt={"local venue"} />
+        <img src={DEFAULT_IMAGE} alt={"default place image"} />
       )}
     </div>
   );

--- a/src/lib/fetchNearbyPlaces.js
+++ b/src/lib/fetchNearbyPlaces.js
@@ -16,7 +16,6 @@ const fetchNearbyPlacesPromise = async (lat, lng) => {
 //executes the fetch, and formats data for consumption by Pin component
 async function fetchNearbyPlaces(lat, lng, setPendingPromise) {
   setPendingPromise(true);
-  console.log("running promise");
   let places = await fetchNearbyPlacesPromise(lat, lng).then(
     (res) => res.query.pages
   );

--- a/src/lib/fetchNearbyPlaces.js
+++ b/src/lib/fetchNearbyPlaces.js
@@ -1,36 +1,39 @@
 //creates promise to fetch data
 const fetchNearbyPlacesPromise = async (lat, lng) => {
-    let url = `https://segdeha.com/api/nearby.php?lat=${lat}&lng=${lng}`
-    let response = await fetch(url);
+  let url = `https://segdeha.com/api/nearby.php?lat=${lat}&lng=${lng}`;
+  let response = await fetch(url);
 
-    let output;
-    if(response.ok){
-        output = await response.json();
-
-    } else {
-        console.log("Error" + response.status);
-        output = { };
-    }
-    return output;
-}
+  let output;
+  if (response.ok) {
+    output = await response.json();
+  } else {
+    console.log("Error" + response.status);
+    output = {};
+  }
+  return output;
+};
 
 //executes the fetch, and formats data for consumption by Pin component
-async function fetchNearbyPlaces(lat, lng) {
-    let places = await fetchNearbyPlacesPromise(lat,lng).then(res => res.query.pages);
-    if(places){
-        return places.map( (place) => {
-            const latitude = parseFloat(place.coordinates[0].lat);
-            const longitude = parseFloat(place.coordinates[0].lon);
-            const description = place.description;
-            const title = place.title;
-            const image = place.thumbnail? place.thumbnail.source: null;
-            const dict = {latitude, longitude, description, title, image};
-            return dict;
-        });
-        } else {
+async function fetchNearbyPlaces(lat, lng, setPendingPromise) {
+  setPendingPromise(true);
+  console.log("running promise");
+  let places = await fetchNearbyPlacesPromise(lat, lng).then(
+    (res) => res.query.pages
+  );
+  if (places) {
+    return places.map((place) => {
+      const latitude = parseFloat(place.coordinates[0].lat);
+      const longitude = parseFloat(place.coordinates[0].lon);
+      const description = place.description;
+      const title = place.title;
+      const image = place.thumbnail ? place.thumbnail.source : null;
+      const dict = { latitude, longitude, description, title, image };
+      return dict;
+    });
+  } else {
     // might want to differentiate between error and no outputs in the future. Currently will render same thing.
-        return [];
-    }
+    return [];
+  }
 }
 
 export default fetchNearbyPlaces;

--- a/src/lib/fetchNearbyPlaces.js
+++ b/src/lib/fetchNearbyPlaces.js
@@ -17,7 +17,7 @@ const fetchNearbyPlacesPromise = async (lat, lng) => {
 async function fetchNearbyPlaces(lat, lng, setPendingPromise) {
   setPendingPromise(true);
   let places = await fetchNearbyPlacesPromise(lat, lng).then(
-    (res) => res.query.pages
+    (res) => res.query.pages?res.query.pages:[]
   );
   if (places) {
     return places.map((place) => {


### PR DESCRIPTION
## Description

- added pendingPromise boolean to track API calls
- added conditional within fetch pins to consider undefined pages response

## Related Issue

closes #7 

## Acceptance Criteria

- [x] Use the user’s lat/lng as input to our call to the nearby API
- [x] Only call the API if we don’t already have a call in progress
- [x] Fix bug where pin loading is choppy on pan

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
| ✓  | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before
![choppy_pins](https://user-images.githubusercontent.com/52062192/85807679-72fc1a80-b707-11ea-91aa-f009e9e9233e.gif)


### After

![not_choppy_pins](https://user-images.githubusercontent.com/52062192/85807688-7b545580-b707-11ea-9dcf-fa899bac6a38.gif)
