### PR TITLE
Welcome Screen - App Title- to Home

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -44,35 +44,6 @@
 }
 
 
-.GoogleMapReact{
-  width: 100%;
-  opacity: 0;
-  position: absolute;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  transition: opacity 0.5s;
-  user-select: none;
-  width: 24px;
-  z-index: 10;
-}
-
-.map-center {
-  height: 24px;
-  left: 50%;
-  opacity: 0;
-  position: absolute;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  transition: opacity 0.5s;
-  user-select: none;
-  width: 24px;
-  z-index: 1;
-}
-
-.map-center.active {
-    opacity: 1;
-  }
-
 .MapCenter {
   height: 24px;
   left: 50%;
@@ -84,6 +55,10 @@
   user-select: none;
   width: 24px;
   z-index: 1;
+  border-radius: 50%;
+  box-sizing: border-box;
+  height: 10px;
+  width: 10px;
 }
 
 
@@ -167,12 +142,4 @@
   50% {
     transform: scale(1.1);
   }
-}
-
-
-.MapCenter {
-  border-radius: 50%;
-  box-sizing: border-box;
-  height: 10px;
-  width: 10px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -66,18 +66,6 @@ function App() {
     window.location.reload(false);
   };
 
-
-  /* const onPositionChanged = (location) => {
-     console.log(`This the new location onPositionChange:${JSON.stringify(location, undefined, 2)}`);
-     const newLocation = new window.google.maps.LatLng(location.lat, location.lng);
-     // [NOTE]: try using the panTo() from googleMaps to recenter the map ? but don't know how to call it.
-     return (
-       <marker
-         position={newLocation}
-       />
-     );
-   }*/
-
   const map = (
     <Map
       nearbyPlaces={nearbyPlaces}
@@ -131,7 +119,6 @@ function App() {
         handleClick={handleClick}
         marker={marker}
         handleLocationSharedClick={handleLocationSharedClick}
-      // onPositionChanged={onPositionChanged}
       />
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -71,7 +71,7 @@ function App() {
     />
   );
 
-  const handleClick = () => {
+  const handlePositionClick = () => {
     allowMarker(true);
     const options = {
       enableHighAccuracy: true,
@@ -101,12 +101,13 @@ function App() {
       <Header
         userHasPanned={userHasPanned}
         setDisplayInformation={setDisplayInformation}
+        map={map}
       />
       <Main map={map} />
       <Footer
         currentPin={currentPin}
         displayInformation={displayInformation}
-        handleClick={handleClick}
+        handlePositionClick={handlePositionClick}
         marker={marker}
         handleLocationSharedClick={handleLocationSharedClick}
       />

--- a/src/App.js
+++ b/src/App.js
@@ -67,7 +67,6 @@ function App() {
       userHasPanned={userHasPanned}
       setUserHasPanned={setUserHasPanned}
       mapsObj={mapsObj}
-      setHome={setHome}
       setMapsObj={setMapsObj}
     />
   );

--- a/src/App.js
+++ b/src/App.js
@@ -113,6 +113,7 @@ function App() {
         userHasPanned={userHasPanned}
         handleCenterClick={handleCenterClick}
         handleTitleClick={handleTitleClick}
+        setDisplayInformation={setDisplayInformation}
       />
       <Main map={map} />
       <Footer

--- a/src/App.js
+++ b/src/App.js
@@ -99,9 +99,11 @@ function App() {
   return (
     <div className="App">
       <Header
-        userHasPanned={userHasPanned}
         setDisplayInformation={setDisplayInformation}
-        map={map}
+        mapsObj={mapsObj}
+        mapProperties={mapProperties}
+        userHasPanned={userHasPanned}
+        setUserHasPanned={setUserHasPanned}
       />
       <Main map={map} />
       <Footer

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ function App() {
   const [displayInformation, setDisplayInformation] = useState(false);
   const [userHasPanned, setUserHasPanned] = useState(false);
   const [mapsObj, setMapsObj] = useState({});
+  const [home, setHome] = useState(null);
   const [currentPin, setCurrentPin] = useState({
     title: null,
     description: null,
@@ -63,8 +64,8 @@ function App() {
   };
 
   const handleTitleClick = () => {
-    window.location.reload(false);
-  };
+    setHome(null);
+  }
 
   const map = (
     <Map
@@ -76,6 +77,7 @@ function App() {
       userHasPanned={userHasPanned}
       setUserHasPanned={setUserHasPanned}
       mapsObj={mapsObj}
+      setHome={setHome}
       setMapsObj={setMapsObj}
     />
   );
@@ -118,6 +120,7 @@ function App() {
         displayInformation={displayInformation}
         handleClick={handleClick}
         marker={marker}
+        home={home}
         handleLocationSharedClick={handleLocationSharedClick}
       />
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -44,7 +44,7 @@ function App() {
     console.warn(`ERROR(${err.code}): ${err.message}`);
   }
 
-  
+
 
   const handleLocationSharedClick = () => {
     allowMarker(true);
@@ -100,8 +100,6 @@ function App() {
     <div className="App">
       <Header
         userHasPanned={userHasPanned}
-        handleCenterClick={handleCenterClick}
-        handleTitleClick={handleTitleClick}
         setDisplayInformation={setDisplayInformation}
       />
       <Main map={map} />
@@ -110,7 +108,6 @@ function App() {
         displayInformation={displayInformation}
         handleClick={handleClick}
         marker={marker}
-        home={home}
         handleLocationSharedClick={handleLocationSharedClick}
       />
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,9 @@ function App() {
   const [marker, allowMarker] = useState(false);
   const [nearbyPlaces, setNearbyPlaces] = useState([]);
   const [displayInformation, setDisplayInformation] = useState(false);
+  const [userHasPanned, setUserHasPanned] = useState(false);
+  const [mapsObj, setMapsObj] = useState({});
+  const [setPlace] = useState(null);
   const [currentPin, setCurrentPin] = useState({
     title: null,
     description: null,
@@ -24,6 +27,60 @@ function App() {
     zoom: 11,
   });
 
+  function getCoordinates(pos) {
+    const crd = pos.coords;
+    let latitude = crd.latitude;
+    let longitude = crd.longitude;
+    setMapProperties({
+      ...mapProperties,
+      center: {
+        lat: latitude,
+        lng: longitude,
+      },
+    });
+    setUserHasPanned(false); // ensures MapCenter dot not displayed when map first moves to user location
+  }
+
+  function logError(err) {
+    console.warn(`ERROR(${err.code}): ${err.message}`);
+  }
+
+  const handleCenterClick = (e) => {
+    const { map } = mapsObj;
+    e.preventDefault();
+    map.setCenter(mapProperties.center);
+    setUserHasPanned(false);
+  };
+
+  const handleLocationSharedClick = () => {
+    allowMarker(true);
+    const options = {
+      enableHighAccuracy: true,
+      timeout: 5000,
+      maximumAge: 0,
+    };
+
+    navigator.geolocation.getCurrentPosition(getCoordinates, logError, options);
+  };
+
+  const handleTitleClick = () => {
+   // setPlace(null);
+    window.location.reload(false);
+  };
+
+
+ /* const onPositionChanged = (location) => {
+    console.log(`This the new location onPositionChange:${JSON.stringify(location, undefined, 2)}`);
+    const newLocation = new window.google.maps.LatLng(location.lat, location.lng);
+    // [NOTE]: try using the panTo() from googleMaps to recenter the map ? but don't know how to call it.
+
+    return (
+      <marker
+        position={newLocation}
+      />
+    );
+  }*/
+
   const map = (
     <Map
       nearbyPlaces={nearbyPlaces}
@@ -31,6 +88,11 @@ function App() {
       setCurrentPin={setCurrentPin}
       setDisplayInformation={setDisplayInformation}
       mapProperties={mapProperties}
+      userHasPanned={userHasPanned}
+      setUserHasPanned={setUserHasPanned}
+      mapsObj={mapsObj}
+      setMapsObj={setMapsObj}
+      setPlace={setPlace}
     />
   );
 
@@ -61,13 +123,18 @@ function App() {
 
   return (
     <div className="App">
-      <Header />
+      <Header
+        userHasPanned={userHasPanned}
+        handleCenterClick={handleCenterClick}
+        handleTitleClick={handleTitleClick}
+      />
       <Main map={map} />
       <Footer
         currentPin={currentPin}
         displayInformation={displayInformation}
         handleClick={handleClick}
         marker={marker}
+      // onPositionChanged={onPositionChanged}
       />
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,6 @@ function App() {
   const [displayInformation, setDisplayInformation] = useState(false);
   const [userHasPanned, setUserHasPanned] = useState(false);
   const [mapsObj, setMapsObj] = useState({});
-  const [home, setHome] = useState(null);
   const [currentPin, setCurrentPin] = useState({
     title: null,
     description: null,
@@ -45,12 +44,7 @@ function App() {
     console.warn(`ERROR(${err.code}): ${err.message}`);
   }
 
-  const handleCenterClick = (e) => {
-    const { map } = mapsObj;
-    e.preventDefault();
-    map.setCenter(mapProperties.center);
-    setUserHasPanned(false);
-  };
+  
 
   const handleLocationSharedClick = () => {
     allowMarker(true);
@@ -62,10 +56,6 @@ function App() {
 
     navigator.geolocation.getCurrentPosition(getCoordinates, logError, options);
   };
-
-  const handleTitleClick = () => {
-    setHome(null);
-  }
 
   const map = (
     <Map

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -54,6 +54,7 @@ Footer.propTypes = {
   displayInformation: PropTypes.bool.isRequired,
   handleLocationSharedClick: PropTypes.func.isRequired,
   marker: PropTypes.bool.isRequired,
+  home: PropTypes.bool.isRequired,
 };
 
 export default Footer;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -18,7 +18,6 @@ const Footer = ({
 
   const defaultFooter = (
     <section>
-    <div>
       <p>
         <strong> Click "Share Location" </strong> to discover interesting
         landmarks around you from Wikipedia
@@ -32,7 +31,6 @@ const Footer = ({
         <strong> What's near me?</strong> Looks and works best when installed
         on your phone as an app.
       </p>
-    </div>
     </section>
   );
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const Header = ({ userHasPanned, setDisplayInformation,setUserHasPanned, mapProperties,map,mapsObj }) => {
+const Header = ({ setDisplayInformation, userHasPanned, setUserHasPanned, mapProperties, mapsObj }) => {
   const greyImg = userHasPanned ? null : "grey-img";
 
   const handleCenterClick = (e) => {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const Header = ({ userHasPanned, setDisplayInformation }) => {
+const Header = ({ userHasPanned, setDisplayInformation,setUserHasPanned, mapProperties,map,mapsObj }) => {
   const greyImg = userHasPanned ? null : "grey-img";
 
   const handleCenterClick = (e) => {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,9 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const Header = ({ userHasPanned, handleCenterClick, handleTitleClick, setDisplayInformation }) => {
+const Header = ({ userHasPanned, setDisplayInformation }) => {
   const greyImg = userHasPanned ? null : "grey-img";
 
+  const handleCenterClick = (e) => {
+    const { map } = mapsObj;
+    e.preventDefault();
+    map.setCenter(mapProperties.center);
+    setUserHasPanned(false);
+  };
   return (
     <header className="header">
       <button className="header-btn" onClick={(handleCenterClick)} to="/">
@@ -21,7 +27,7 @@ const Header = ({ userHasPanned, handleCenterClick, handleTitleClick, setDisplay
 Header.propTypes = {
   userHasPanned: PropTypes.bool.isRequired,
   handleCenterClick: PropTypes.func.isRequired,
-  handleTitleClick: PropTypes.func.isRequired
+  setDisplayInformation: PropTypes.func.isRequired
 };
 
 export default Header;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -10,9 +10,10 @@ const Header = ({ userHasPanned, setDisplayInformation,setUserHasPanned, mapProp
     map.setCenter(mapProperties.center);
     setUserHasPanned(false);
   };
+
   return (
     <header className="header">
-      <button className="header-btn" onClick={(handleCenterClick)} to="/">
+      <button className="header-btn" onClick={handleCenterClick} to="/">
         <img
           src="/img/center-on-me.png"
           alt="center on me"
@@ -27,7 +28,7 @@ const Header = ({ userHasPanned, setDisplayInformation,setUserHasPanned, mapProp
 Header.propTypes = {
   userHasPanned: PropTypes.bool.isRequired,
   handleCenterClick: PropTypes.func.isRequired,
-  setDisplayInformation: PropTypes.func.isRequired
+  setDisplayInformation: PropTypes.func.isRequired,
 };
 
 export default Header;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,19 +1,19 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const Header = ({ userHasPanned, handleCenterClick, handleTitleClick }) => {
+const Header = ({ userHasPanned, handleCenterClick, handleTitleClick, setDisplayInformation }) => {
   const greyImg = userHasPanned ? null : "grey-img";
 
   return (
     <header className="header">
-      <button className="header-btn" onClick={handleCenterClick} to="/">
+      <button className="header-btn" onClick={(handleCenterClick)} to="/">
         <img
           src="/img/center-on-me.png"
           alt="center on me"
           className={greyImg}
         />
       </button>
-      <button className="welcome" onClick={handleTitleClick}>What's near me?</button>
+      <button className="welcome" onClick={() => setDisplayInformation(false)}>What's near me?</button>
     </header>
   );
 };

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -31,7 +31,13 @@ const Header = ({ setDisplayInformation, userHasPanned, setUserHasPanned, mapPro
             className={greyImg}
           />
         </button>
-        What's near me?
+
+        <button 
+            className="welcome"
+            onClick={() => setDisplayInformation(false)}
+        >
+                What's near me?
+        </button>
         <button
           className="header-settings-btn"
           onClick={() => setDisplayModal(true)}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,7 +1,32 @@
-import React from "react";
+import React  from "react";
+import PropTypes from "prop-types";
 
-const Header = () => {
-  return <header className="header">What's near me?</header>;
+const Header = ({ userHasPanned, handleCenterClick , handleTitleClick}) => {
+  const greyImg = userHasPanned ? null : "grey-img";
+  //const [setPlace] = useState(null);
+
+ /* const handleTitleClick = evt => {
+    setPlace(null);
+  };*/
+
+  return (
+    <header className="header">
+      <button className= "header-btn" onClick = { handleCenterClick } to="/">
+        <img
+          src="/img/center-on-me.png"
+          alt="center on me"
+          className={greyImg}
+        />
+      </button>
+      <button className= "welcome" onClick={handleTitleClick}>What's near me?</button>
+    </header>
+  );
+};
+
+Header.propTypes = {
+  userHasPanned: PropTypes.bool.isRequired,
+  handleCenterClick: PropTypes.func.isRequired,
+  handleTitleClick:PropTypes.func.isRequired
 };
 
 export default Header;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -11,6 +11,14 @@ const Map = ({
   setCurrentPin,
   setDisplayInformation,
   mapProperties,
+  userHasPanned,
+  setUserHasPanned,
+  mapsObj,
+  setMapsObj,
+  setMapProperties,
+  //handleCenterChanged,
+ // onPositionChanged,
+  center,
 }) => {
   useEffect(() => {
     fetchNearbyPlaces(
@@ -45,6 +53,7 @@ const Map = ({
           lat={mapProperties.center.lat}
           lng={mapProperties.center.lng}
         />
+        <MapCenter userHasPanned={userHasPanned} handleCenterChanged={handleCenterChanged} /*onPositionChanged={onPositionChanged}*//>
       </GoogleMapReact>
     </div>
   );
@@ -56,6 +65,12 @@ Map.propTypes = {
   setCurrentPin: PropTypes.func.isRequired,
   setDisplayInformation: PropTypes.func.isRequired,
   mapProperties: PropTypes.object.isRequired,
+  userHasPanned: PropTypes.bool.isRequired,
+  setUserHasPanned: PropTypes.func.isRequired,
+  mapsObj: PropTypes.object.isRequired,
+  setMapsObj: PropTypes.func.isRequired,
+ /* onPositionChanged:PropTypes.func.isRequired,
+  handleCenterChanged: PropTypes.func.isRequired,*/
 };
 
 export default Map;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -92,6 +92,8 @@ Map.propTypes = {
   setUserHasPanned: PropTypes.func.isRequired,
   mapsObj: PropTypes.object.isRequired,
   setMapsObj: PropTypes.func.isRequired,
+  setHome: PropTypes.func.isRequired,
+  home: PropTypes.object.isRequired,
 };
 
 export default Map;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -51,7 +51,7 @@ const Map = ({
         bootstrapURLKeys={{ key: "AIzaSyA_jF-TPUl8qTMZ3BKFTrFOolH9wR7NOz4" }}
         center={mapProperties.center}
         zoom={mapProperties.zoom}
-        options={{ clickableIcons: false }}
+        options={{ clickableIcons: false, gestureHandling: "greedy" }}
         handleCenterChanged={handleCenterChanged}
         yesIWantToUseGoogleMapApiInternals
         onGoogleApiLoaded={setMapsObj}

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -18,8 +18,6 @@ const Map = ({
   mapsObj,
   setMapsObj,
   setMapProperties,
-  //handleCenterChanged,
-  // onPositionChanged,
   center,
 }) => {
   useEffect(() => {
@@ -29,32 +27,26 @@ const Map = ({
     ).then((res) => setNearbyPlaces(res));
   }, [mapProperties.center.lat, mapProperties.center.lng, setNearbyPlaces]);
 
+
   // only runs if maps object is populated
   if (!isObjEmpty(mapsObj)) {
     const { map } = mapsObj;
     map.addListener("center_changed", function () {
       setUserHasPanned(true);
-      // handleCenterChanged();
     });
-  }
+  };
+
 
   function handleCenterChanged() {
-    const center = {
-      latitude: mapProperties.center.lat,
-      longitude: mapProperties.center.lng,
-    };
-    // this.mapProperties.getCoordinates();
+    const center = this.mapProperties.getCoordinates();
     if (!center.equals(mapProperties.center.lat, mapProperties.center.lng)) {
       setMapProperties({ center });
       setNearbyPlaces();
     }
-  }
+  };
 
   return (
-    <div
-      className="Map"
-      style={{ height: "calc(66.67vh - 1.25rem)", width: "100%" }}
-    >
+    <div className="Map" style={{ height: "calc(66.67vh - 1.25rem)", width: "100%" }}>
       <GoogleMapReact
         bootstrapURLKeys={{ key: "AIzaSyA_jF-TPUl8qTMZ3BKFTrFOolH9wR7NOz4" }}
         center={mapProperties.center}
@@ -63,7 +55,6 @@ const Map = ({
         handleCenterChanged={handleCenterChanged}
         yesIWantToUseGoogleMapApiInternals
         onGoogleApiLoaded={setMapsObj}
-        // onGoogleApiLoaded={(map, maps) => handleApiLoaded(map, maps)}
       >
         {nearbyPlaces &&
           nearbyPlaces.map((place, index) => (
@@ -76,8 +67,6 @@ const Map = ({
               img={place.image}
               setCurrentPin={setCurrentPin}
               setDisplayInformation={setDisplayInformation}
-              // handleCenterChanged={handleCenterChanged}
-              // onPositionChanged={onPositionChanged}
               center={center}
             />
           ))}
@@ -86,15 +75,12 @@ const Map = ({
           lat={mapProperties.center.lat}
           lng={mapProperties.center.lng}
         />
-        <MapCenter
-          userHasPanned={userHasPanned}
-          // handleCenterChanged={handleCenterChanged}
-          // onPositionChanged={onPositionChanged}
-        />
+        <MapCenter userHasPanned={userHasPanned} handleCenterChanged={handleCenterChanged}/>
       </GoogleMapReact>
     </div>
   );
 };
+
 
 Map.propTypes = {
   nearbyPlaces: PropTypes.array.isRequired,
@@ -106,8 +92,6 @@ Map.propTypes = {
   setUserHasPanned: PropTypes.func.isRequired,
   mapsObj: PropTypes.object.isRequired,
   setMapsObj: PropTypes.func.isRequired,
-  onPositionChanged: PropTypes.func.isRequired,
-  handleCenterChanged: PropTypes.func.isRequired,
 };
 
 export default Map;

--- a/src/components/PinDescription.js
+++ b/src/components/PinDescription.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { firstCap } from "../lib/DescriptionRules";
 
-const PinDescription = ({ title, image, description }) => {
+const PinDescription = ({ title, image, description, }) => {
   const DEFAULT_IMAGE = "/img/default-thumb.png";
   const wikipedia = `https://www.wikipedia.org/search-redirect.php?search=${title}&family=wikipedia&hiddenLanguageInput=en`;
 

--- a/src/components/PinDescription.js
+++ b/src/components/PinDescription.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { firstCap } from "../lib/DescriptionRules";
 
-const PinDescription = ({ title, image, description, }) => {
+const PinDescription = ({ title, image, description }) => {
   const DEFAULT_IMAGE = "/img/default-thumb.png";
   const wikipedia = `https://www.wikipedia.org/search-redirect.php?search=${title}&family=wikipedia&hiddenLanguageInput=en`;
 


### PR DESCRIPTION
## Description

When the user taps the title of the App , the app returns to the original screen when the app first opens.

## Related Issue
close #12 


## Acceptance Criteria

- [x] User can tap the app title (the name of the app in the Header component) to return the app to showing the original screen that shows in the Footer when the app first opens)

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### After
![image](https://user-images.githubusercontent.com/15656643/83706335-31cf8980-a5e5-11ea-8068-a043b532270d.png)



