### PR TITLE
Adding videos to walk users through adding the app to their home screen

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "Materalize",
         "allowmarker",
         "headerbtn",
         "headerbutton"

--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,1 @@
+[0617/181859.553:ERROR:exit_code_watcher_win.cc(87)] Failed to wait for process exit or stop event

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,12 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+     <!-- Compiled and minified CSS -->
+     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+
+     <!-- Compiled and minified JavaScript -->
+     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+             
     <title>React App</title>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -25,10 +25,9 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
      <!-- Compiled and minified CSS -->
-     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"> -->
 
-     <!-- Compiled and minified JavaScript -->
-     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+     
              
     <title>React App</title>
   </head>
@@ -45,5 +44,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+  <!-- Compiled and minified JavaScript -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -25,10 +25,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
      <!-- Compiled and minified CSS -->
-     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"> -->
 
-     
-             
     <title>React App</title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -194,6 +194,8 @@
   width: 20px;
 }
 
+
+
 /* sets root appearance of modal itself once opened */
 .modal-content {
   display: inline-block;
@@ -206,7 +208,8 @@
 }
 .modal-accordian {
 margin: 0 auto;
-margin-top: 15px;
+margin-top: 35px;
+width:50%;
 }
 
 .modal-header {
@@ -243,6 +246,24 @@ margin-top: 15px;
   text-align: center;
   font-size: 1.25rem;
 }
+/*Videos Modal styling*/
+
+.modal-content-videos {
+  display: inline-block;
+  background-color: white;
+  box-shadow: 0px -1px 0px rgba(0, 0, 0, 0.1);
+  border-radius: 20px;
+  padding: 1rem;
+  width: 80vw;
+  height: 80vh;
+}
+
+.modal-accordian {
+margin: 0 auto;
+margin-top: 35px;
+width:50%;
+}
+
 
 /* Mobile Styles */
 @media (max-width: 700px) {

--- a/src/App.css
+++ b/src/App.css
@@ -45,33 +45,36 @@
   min-height: calc(66.67vh - 1.25rem);
 }
 
-.GoogleMapReact {
-  width: 100%;
-  opacity: 0;
+.App-info {
+  background: white;
+  bottom: 0;
+  flex-direction: column;
+  height: 40%;
+  left: 0;
+  overflow: scroll;
   position: absolute;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  transition: opacity 0.5s;
-  user-select: none;
-  width: 24px;
-  z-index: 10;
+  right: 0;
+  transition: height 0.5s;
 }
 
-.map-center {
-  height: 24px;
-  left: 50%;
-  opacity: 0;
-  position: absolute;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  transition: opacity 0.5s;
-  user-select: none;
-  width: 24px;
-  z-index: 1;
+.App-info-container {
+  padding: 0 1rem 1rem;
 }
+  .App-info-container article {
+    text-align: left;
+  }
+  .App-info-container details {
+    margin: 1rem 0;
+  }
+  .App-info-container img {
+    max-width: 100%;
+  }
 
-.map-center.active {
-  opacity: 1;
+.App-info-how-to {
+  display: block;
+  height: 60vh;
+  margin: auto;
+  width: auto;
 }
 
 .MapCenter {
@@ -216,9 +219,3 @@
   }
 }
 
-.MapCenter {
-  border-radius: 50%;
-  box-sizing: border-box;
-  height: 10px;
-  width: 10px;
-}

--- a/src/App.css
+++ b/src/App.css
@@ -72,9 +72,7 @@
 
 .App-info-how-to {
   display: block;
-  height: 60vh;
-  margin: auto;
-  width: auto;
+  height: 40vh;
 }
 
 .MapCenter {
@@ -183,6 +181,10 @@
   padding: 1rem;
   width: 80vw;
   height: 80vh;
+}
+.modal-accordian {
+margin: 0 auto;
+margin-top: 15px;
 }
 
 .modal-header {

--- a/src/App.js
+++ b/src/App.js
@@ -25,7 +25,6 @@ function App() {
     },
     zoom: 11,
     panning: false,
-   // onPositionChanged: () => {},
   });
 
   function getCoordinates(pos) {
@@ -64,18 +63,6 @@ function App() {
     navigator.geolocation.getCurrentPosition(getCoordinates, logError, options);
   };
 
-  const onPositionChanged = (location) => {
-    console.log(`This the new location onPositionChange:${JSON.stringify(location, undefined, 2)}`);
-    const newLocation = new window.google.maps.LatLng(location.lat, location.lng);
-    // [NOTE]: try using the panTo() from googleMaps to recenter the map ? but don't know how to call it.
-
-    return (
-      <marker
-        position={newLocation}
-      />
-    );
-  }
-
   const map = (
     <Map
       nearbyPlaces={nearbyPlaces}
@@ -102,7 +89,6 @@ function App() {
         displayInformation={displayInformation}
         handleLocationSharedClick={handleLocationSharedClick}
         marker={marker}
-        onPositionChanged={onPositionChanged}
       />
     </div>
   );

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,6 +1,7 @@
-import React from "react";
+import React, {useState, Fragment}from "react";
 import PropTypes from "prop-types";
 import PinDescription from "./PinDescription";
+import VideosModal from "./VideosModal"
 
 const Footer = ({
   currentPin,
@@ -15,28 +16,36 @@ const Footer = ({
       image={currentPin.image}
     />
   );
+  const [VideoModal, setVideoModal] = useState(false);
 
   const defaultFooter = (
     <section>
-    <div>
-      <p>
-        <strong> Click "Share Location" </strong> to discover interesting
-        landmarks around you from Wikipedia
-      </p>
-      <p>
-        <strong> Tap on a marker </strong> on the map and more information about
-        it will show up in this space. Have fun!
-      </p>
-      <p>Note: Your location is never stored in the app or on our servers!</p>
-      <p>
-        <strong> What's near me?</strong> Looks and works best when installed
-        on your phone as an app.
-      </p>
-    </div>
+      <div>
+        <p>
+          <strong> Click "Share Location" </strong> to discover interesting
+          landmarks around you from Wikipedia
+        </p>
+        <p>
+          <strong> Tap on a marker </strong> on the map and more information
+          about it will show up in this space. Have fun!
+        </p>
+        <p>Note: Your location is never stored in the app or on our servers!</p>
+        <p>
+          <strong> What's near me?</strong> Looks and works best when installed
+          on your phone as an app.
+        </p>
+        <button onClick={() => setVideoModal(true)}>
+          Click here for How to install
+        </button>
+      </div>
     </section>
   );
 
   return (
+    <Fragment>
+
+      {VideoModal && <VideosModal setVideoModal={setVideoModal} />}
+
     <footer className="footer">
       <h1>
         {marker ? (
@@ -47,7 +56,8 @@ const Footer = ({
       </h1>
 
       {displayInformation ? descriptionFooter : defaultFooter}
-    </footer>
+  </footer>
+  </Fragment>
   );
 };
 
@@ -56,6 +66,7 @@ Footer.propTypes = {
   displayInformation: PropTypes.bool.isRequired,
   handleLocationSharedClick: PropTypes.func.isRequired,
   marker: PropTypes.bool.isRequired,
+  setVideoModal: PropTypes.func.isRequired
 };
 
 export default Footer;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -65,8 +65,7 @@ Footer.propTypes = {
   currentPin: PropTypes.object.isRequired,
   displayInformation: PropTypes.bool.isRequired,
   handleLocationSharedClick: PropTypes.func.isRequired,
-  marker: PropTypes.bool.isRequired,
-  setVideoModal: PropTypes.func.isRequired
+  marker: PropTypes.bool.isRequired
 };
 
 export default Footer;

--- a/src/components/VideosModal.js
+++ b/src/components/VideosModal.js
@@ -1,0 +1,40 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export default function VideosModal({ setVideoModal }) {
+  return (
+    <div id="modal" className="modal-container">
+      <section className="modal-content">
+        <img
+          src={"/img/close-x.png"}
+          alt="close icon"
+          onClick={() => setVideoModal(false)}
+          className="modal-close-button"
+        />
+        <h1 className="modal-header">Videos</h1>
+        <h3>How to:Ios</h3>
+        <video
+          className="App-info-how-to"
+          //poster={`/img/screen-grab-ios.png`}
+          controls
+          preload="metadata"
+        >
+          <source src={`/img/screen-cast-ios.mp4`} type="video/mp4" />
+        </video>
+        <h3>How to:Android</h3>
+        <video
+          className="App-info-how-to"
+         // poster={`/img/screen-grab-android.png`}
+          controls
+          preload="metadata"
+        >
+          <source src={`/img/screen-cast-android.mp4`} type="video/mp4" />
+        </video>
+      </section>
+    </div>
+  );
+}
+
+VideosModal.propTypes = {
+  setVideoModal: PropTypes.func.isRequired,
+};

--- a/src/components/VideosModal.js
+++ b/src/components/VideosModal.js
@@ -15,7 +15,7 @@ export default function VideosModal({ setVideoModal }) {
         <img
           src={"/img/close-x.png"}
           alt="close icon"
-          className="modal-close-button"
+          className="modal-close-img"
         />
         </button>
         <div>

--- a/src/components/VideosModal.js
+++ b/src/components/VideosModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import {Collapsible, CollapsibleItem, Icon } from 'react-materialize';
+import {Collapsible, CollapsibleItem} from 'react-materialize';
 
 export default function VideosModal({ setVideoModal }) {
   return (
@@ -23,7 +23,6 @@ export default function VideosModal({ setVideoModal }) {
           >
             <video
               className="App-info-how-to"
-              //poster={`/img/screen-grab-ios.png`}
               controls
               preload="metadata"
             >
@@ -37,14 +36,13 @@ export default function VideosModal({ setVideoModal }) {
           >
               <video
                 className="App-info-how-to"
-              // poster={`/img/screen-grab-android.png`}
                 controls
                 preload="metadata"
               >
                 <source src={`/img/screen-cast-android.mp4`} type="video/mp4" />
               </video>
           </CollapsibleItem>
-        
+
         </Collapsible>
       </section>
     </div>

--- a/src/components/VideosModal.js
+++ b/src/components/VideosModal.js
@@ -14,11 +14,10 @@ export default function VideosModal({ setVideoModal }) {
           onClick={() => setVideoModal(false)}
           className="modal-close-button"
         />
-        <h1 className="modal-header">Videos</h1>
-        <Collapsible accordion={true}>
+        <Collapsible accordion={true} className="modal-accordian">
           <CollapsibleItem
               expanded={false}
-              header="iOS Instructions"
+              header="IOS Instructions"
               node="div"
           >
             <video

--- a/src/components/VideosModal.js
+++ b/src/components/VideosModal.js
@@ -8,12 +8,17 @@ export default function VideosModal({ setVideoModal }) {
       {/* React Materalize import */}
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"></link>
       <section className="modal-content">
+        <button
+          className="modal-close-button"
+          onClick={() => setVideoModal(false)}
+        >
         <img
           src={"/img/close-x.png"}
           alt="close icon"
-          onClick={() => setVideoModal(false)}
           className="modal-close-button"
         />
+        </button>
+        <div>
         <Collapsible accordion={true} className="modal-accordian">
           <CollapsibleItem
               expanded={false}
@@ -43,6 +48,7 @@ export default function VideosModal({ setVideoModal }) {
           </CollapsibleItem>
 
         </Collapsible>
+        </div>
       </section>
     </div>
   );

--- a/src/components/VideosModal.js
+++ b/src/components/VideosModal.js
@@ -9,13 +9,13 @@ export default function VideosModal({ setVideoModal }) {
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"></link>
       <section className="modal-content-videos">
         <button
-          className="modal-close-button-videos"
+          className="modal-close-button"
           onClick={() => setVideoModal(false)}
         >
         <img
           src={"/img/close-x.png"}
           alt="close icon"
-          className="modal-close-img-videos"
+          className="modal-close-img"
         />
         </button>
         <div className="modal-accordian">

--- a/src/components/VideosModal.js
+++ b/src/components/VideosModal.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import {Collapsible, CollapsibleItem, Icon } from 'react-materialize';
 
 export default function VideosModal({ setVideoModal }) {
   return (
@@ -12,24 +13,37 @@ export default function VideosModal({ setVideoModal }) {
           className="modal-close-button"
         />
         <h1 className="modal-header">Videos</h1>
-        <h3>How to:Ios</h3>
-        <video
-          className="App-info-how-to"
-          //poster={`/img/screen-grab-ios.png`}
-          controls
-          preload="metadata"
-        >
-          <source src={`/img/screen-cast-ios.mp4`} type="video/mp4" />
-        </video>
-        <h3>How to:Android</h3>
-        <video
-          className="App-info-how-to"
-         // poster={`/img/screen-grab-android.png`}
-          controls
-          preload="metadata"
-        >
-          <source src={`/img/screen-cast-android.mp4`} type="video/mp4" />
-        </video>
+        <Collapsible accordion={true}>
+          <CollapsibleItem
+              expanded={false}
+              header="iOS Instructions"
+              node="div"
+          >
+            <video
+              className="App-info-how-to"
+              //poster={`/img/screen-grab-ios.png`}
+              controls
+              preload="metadata"
+            >
+              <source src={`/img/screen-cast-ios.mp4`} type="video/mp4" />
+            </video>
+          </CollapsibleItem>
+          <CollapsibleItem
+              expanded={false}
+              header="Android Instructions"
+              node="div"
+          >
+              <video
+                className="App-info-how-to"
+              // poster={`/img/screen-grab-android.png`}
+                controls
+                preload="metadata"
+              >
+                <source src={`/img/screen-cast-android.mp4`} type="video/mp4" />
+              </video>
+          </CollapsibleItem>
+        
+        </Collapsible>
       </section>
     </div>
   );

--- a/src/components/VideosModal.js
+++ b/src/components/VideosModal.js
@@ -5,6 +5,8 @@ import {Collapsible, CollapsibleItem, Icon } from 'react-materialize';
 export default function VideosModal({ setVideoModal }) {
   return (
     <div id="modal" className="modal-container">
+      {/* React Materalize import */}
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"></link>
       <section className="modal-content">
         <img
           src={"/img/close-x.png"}

--- a/src/components/VideosModal.js
+++ b/src/components/VideosModal.js
@@ -7,19 +7,19 @@ export default function VideosModal({ setVideoModal }) {
     <div id="modal" className="modal-container">
       {/* React Materalize import */}
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"></link>
-      <section className="modal-content">
+      <section className="modal-content-videos">
         <button
-          className="modal-close-button"
+          className="modal-close-button-videos"
           onClick={() => setVideoModal(false)}
         >
         <img
           src={"/img/close-x.png"}
           alt="close icon"
-          className="modal-close-img"
+          className="modal-close-img-videos"
         />
         </button>
-        <div>
-        <Collapsible accordion={true} className="modal-accordian">
+        <div className="modal-accordian">
+        <Collapsible accordion={true}>
           <CollapsibleItem
               expanded={false}
               header="IOS Instructions"


### PR DESCRIPTION
## Description

We placed a button in the footer for the user to click, this opens up a modal where both videos are held. We applied Materialize in the modal to display the videos. This code needs further CSS changes and perhaps further structure but have a look!

## Related Issue

closes #10 

## Acceptance Criteria

- [x] In the Footer should appear some help text prompting the user to add the app to their home screen

- [x] Below the help text should be 2 links, 1 for “How to: iOS” and 1 for “How to: Android”

- [x] When the user taps one of the links, it should open a modal

- [x] In the modal, a video should display that shows a user adding the app to their home screen for the operating system selected (you can use public/img/screen-cast-android.mp4 and public/img/screen-cast-ios.mp4)

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

![Screenshot -modal](https://user-images.githubusercontent.com/33047435/84554992-6f13d580-accf-11ea-913d-354013da5a1c.png)
![Screenshot-button click](https://user-images.githubusercontent.com/33047435/84554995-72a75c80-accf-11ea-90aa-5e6c3c8a45b5.png)


## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

